### PR TITLE
Allow to specify `bucket` override

### DIFF
--- a/lib/paperclip/storage/backblaze.rb
+++ b/lib/paperclip/storage/backblaze.rb
@@ -41,6 +41,7 @@ module Paperclip
     module Backblaze
       def self.extended(base)
         base.instance_eval do
+          @b2_buckets = {}
           login
           unless @options[:url] =~ /\Ab2.*url\z/
             @options[:url] = ':b2_path_url'.freeze
@@ -80,8 +81,9 @@ module Paperclip
       # Return the Backblaze::B2::Bucket object representing the bucket
       # specified by the required options[:b2_bucket].
       def b2_bucket
-        @b2_bucket ||= ::Backblaze::B2::Bucket.get_bucket(
-          name: b2_credentials.fetch(:bucket)
+        bucket_name = @options[:bucket] || b2_credentials.fetch(:bucket)
+        @b2_buckets[bucket_name] ||= ::Backblaze::B2::Bucket.get_bucket(
+          name: bucket_name
         )
       end
 

--- a/paperclip-backblaze.gemspec
+++ b/paperclip-backblaze.gemspec
@@ -1,7 +1,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'paperclip-backblaze'
-  spec.version       = '0.20'
+  spec.version       = '0.21'
   spec.authors       = ['Alex Tsui', 'Winston Durand']
   spec.email         = ['alextsui05@gmail.com']
 


### PR DESCRIPTION
Allow user to specify `bucket` option, which will override a default one, specified in the config.
```
  has_attached_file :dl_photo,
    bucket: 'validations',
    path: '/dl/:spree_user_id.:extension',
```

addresses https://github.com/alextsui05/paperclip-backblaze/issues/5